### PR TITLE
ENH: new function that can zip matrices zip_j A.dot(B_j)

### DIFF
--- a/src/sparse_dot_topn/__init__.py
+++ b/src/sparse_dot_topn/__init__.py
@@ -2,8 +2,19 @@
 import importlib.metadata
 
 __version__ = importlib.metadata.version("sparse_dot_topn")
-from sparse_dot_topn.api import awesome_cossim_topn, sp_matmul_topn
+from sparse_dot_topn.api import (
+    awesome_cossim_topn,
+    sp_matmul_topn,
+    sp_matzip_topn_sorted,
+)
 from sparse_dot_topn.lib import _sparse_dot_topn_core as _core
 from sparse_dot_topn.lib._sparse_dot_topn_core import _has_openmp_support
 
-__all__ = ["awesome_cossim_topn", "sp_matmul_topn", "_core", "__version__", "_has_openmp_support"]
+__all__ = [
+    "awesome_cossim_topn",
+    "sp_matmul_topn",
+    "sp_matzip_topn_sorted",
+    "_core",
+    "__version__",
+    "_has_openmp_support",
+]

--- a/src/sparse_dot_topn/api.py
+++ b/src/sparse_dot_topn/api.py
@@ -19,11 +19,23 @@ __all__ = ["sp_matmul_topn", "awesome_cossim_topn"]
 
 _N_CORES = psutil.cpu_count(logical=False) - 1
 
-_SUPPORTED_DTYPES = {np.dtype("int32"), np.dtype("int64"), np.dtype("float32"), np.dtype("float64")}
+_SUPPORTED_DTYPES = {
+    np.dtype("int32"),
+    np.dtype("int64"),
+    np.dtype("float32"),
+    np.dtype("float64"),
+}
 
 
 def awesome_cossim_topn(
-    A, B, ntop, lower_bound=0, use_threads=False, n_jobs=1, return_best_ntop=None, test_nnz_max=None
+    A,
+    B,
+    ntop,
+    lower_bound=0,
+    use_threads=False,
+    n_jobs=1,
+    return_best_ntop=None,
+    test_nnz_max=None,
 ):
     """This function will be removed and replaced with `sp_matmul_topn`.
 
@@ -67,7 +79,9 @@ def awesome_cossim_topn(
         raise DeprecationWarning(msg)
     warnings.warn(msg, DeprecationWarning, stacklevel=2)
     n_threads = n_jobs if use_threads is True else None
-    C = sp_matmul_topn(A=A, B=B, top_n=ntop, threshold=lower_bound, sort=True, n_threads=n_threads)
+    C = sp_matmul_topn(
+        A=A, B=B, top_n=ntop, threshold=lower_bound, sort=True, n_threads=n_threads
+    )
     if return_best_ntop:
         return C, np.diff(C.indptr).max()
     return C
@@ -121,7 +135,11 @@ def sp_matmul_topn(
     density: float = density or 1.0
     idx_dtype = assert_idx_dtype(idx_dtype)
 
-    if isinstance(A, csc_matrix) and isinstance(B, csc_matrix) and A.shape[0] == B.shape[1]:
+    if (
+        isinstance(A, csc_matrix)
+        and isinstance(B, csc_matrix)
+        and A.shape[0] == B.shape[1]
+    ):
         A = A.transpose()
         B = B.transpose()
     elif isinstance(A, (coo_matrix, csc_matrix)):
@@ -144,9 +162,7 @@ def sp_matmul_topn(
         B = B.transpose() if isinstance(B, csc_matrix) else B.transpose().tocsr(False)
         B_nrows, B_ncols = B.shape
     else:
-        msg = (
-            "Matrices `A` and `B` have incompatible shapes. `A.shape[1]` must be equal to `B.shape[0]` or `B.shape[1]`."
-        )
+        msg = "Matrices `A` and `B` have incompatible shapes. `A.shape[1]` must be equal to `B.shape[0]` or `B.shape[1]`."
         raise ValueError(msg)
 
     assert_supported_dtype(A)
@@ -186,8 +202,81 @@ def sp_matmul_topn(
         if _core._has_openmp_support:
             kwargs["n_threads"] = n_threads
             kwargs.pop("density")
-            func = _core.sp_matmul_topn_mt if not sort else _core.sp_matmul_topn_sorted_mt
+            func = (
+                _core.sp_matmul_topn_mt if not sort else _core.sp_matmul_topn_sorted_mt
+            )
         else:
             msg = "sparse_dot_topn: extension was compiled without parallelisation (OpenMP) support, ignoring ``n_threads``"
             warnings.warn(msg, stacklevel=1)
     return csr_matrix(func(**kwargs), shape=(A_nrows, B_ncols))
+
+
+def sp_matzip_topn_sorted(
+    top_n: int,
+    nrowsA: int,
+    ncolsB: list,
+    C_mats: list[csr_matrix],
+) -> csr_matrix:
+    """Compute zip-matrix C = zip_i C_i = zip_i A * B_i = A * B whilst only storing the `top_n` elements.
+
+    Pre-calling this function, matrix B has been split row-wise into chunks B_i, and C_i = A * B_i have been calculated.
+    This function computes C = zip_i C_i, which is equivalent to A * B when only keeping the `top_n` elements.
+    It allows very large matrices to be split and multiplied with a limited memory footprint.
+
+    Args:
+        top_n: the number of results to retain
+        nrowsA: the number of rows in A, LHS of the multiplication.
+        ncolsB: a list with the number of columns in each B_i sub-matrix, RHS of the multiplication.
+        C_mats: a list with each C_i sub-matrix, with format csr_matrix.
+
+    Returns:
+        C: zipped result matrix
+    """
+    # triviality tests
+    assert top_n >= 1
+    assert nrowsA >= 1
+    assert len(ncolsB) >= 1
+    assert all(nB >= 1 for nB in ncolsB)
+    assert len(ncolsB) == len(C_mats)
+    assert all(nrowsA + 1 == len(C_mat.indptr) for C_mat in C_mats)
+
+    ncolsB_tot = sum(ncolsB)
+    nrowsZ_max = min(top_n * nrowsA, sum(C.size for C in C_mats))
+
+    Z_indptr = np.zeros(nrowsA + 1, dtype=C_mats[0].indptr.dtype)
+    Z_indices = np.zeros(nrowsZ_max, dtype=C_mats[0].indices.dtype)
+    Z_data = np.zeros(nrowsZ_max, dtype=C_mats[0].data.dtype)
+
+    # offset, used below, is cumulative sum of number of rows already processed
+    offset = [0] * len(ncolsB)
+    for mi in range(len(ncolsB) - 1):
+        for mj in range(mi, len(ncolsB) - 1):
+            offset[mj + 1] += ncolsB[mi]
+
+    n_set = 0
+    for i in range(nrowsA):
+        # collect all corresponding rows
+        d_zip = {}
+        for mi, C_mat in enumerate(C_mats):
+            for j in range(C_mat.indptr[i], C_mat.indptr[i + 1]):
+                d_zip[offset[mi] + C_mat.indices[j]] = C_mat.data[j]
+
+        # sort by key in reverse order - this mimics the reverse insertion into maxheap,
+        # as in sp_matmul_topn function, which uses a linked list in reverse order.
+        d_zip = dict(sorted(d_zip.items(), reverse=True))
+        # then sort by value and apply topn selection
+        d_zip = dict(sorted(d_zip.items(), key=lambda item: item[1], reverse=True))
+        d_topn = {k: d_zip[k] for k in list(d_zip)[:top_n]}
+
+        # fill the zip-matrix
+        keys = list(d_topn.keys())
+        k = len(keys)
+        Z_indptr[i + 1] = n_set + k
+        for ki, key in enumerate(keys):
+            Z_indices[n_set + ki] = key
+            Z_data[n_set + ki] = d_topn[key]
+        n_set += k
+
+    # func = _core.sp_matzip_topn_sorted
+    # return csr_matrix(func(**kwargs), shape=(nrowsA, ncolsB_tot))
+    return csr_matrix((Z_data, Z_indices, Z_indptr), shape=(nrowsA, ncolsB_tot))

--- a/src/sparse_dot_topn_core/include/sparse_dot_topn/maxheap.hpp
+++ b/src/sparse_dot_topn_core/include/sparse_dot_topn/maxheap.hpp
@@ -96,7 +96,7 @@ class MaxHeap {
     }
 
     /**
-     * \brief Sort the heap accoring to the insertion order.
+     * \brief Sort the heap according to the insertion order.
      *
      * \details Note that calling `insertion_sort` invalidates the heap.
      * Calls should be followed by a call to `reset`.
@@ -106,7 +106,7 @@ class MaxHeap {
     }
 
     /**
-     * \brief Sort the heap accoring to values.
+     * \brief Sort the heap according to values.
      *
      * \details Note that calling `value_sort` invalidates the heap.
      * Calls should be followed by a call to `reset`.

--- a/src/sparse_dot_topn_core/include/sparse_dot_topn/sp_matmul_topn.hpp
+++ b/src/sparse_dot_topn_core/include/sparse_dot_topn/sp_matmul_topn.hpp
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <algorithm>
+#include <limits>
 #include <memory>
 #include <numeric>
 #include <tuple>
@@ -367,5 +368,84 @@ inline std::tuple<size_t, eT*, idxT*, idxT*> sp_matmul_topn_mt(
     return std::make_tuple(total_nonzero, C_data, C_indices, C_indptr);
 }  // sp_matmul_topn_mt
 #endif  // SDTN_OMP_ENABLED
+
+/**
+ * \brief Zip and compute Z = zip_j C_j = zip_j A.dot(B_j) keeping only the top-n of the zipped results.
+ *
+ * \details This function will return a zipped matrix Z in CSR format, zip_j C_j, where
+ * Z = [sorted top n results > lower_bound for each row of C_j], where C_j = A.dot(B_j) and where B
+ * has been split row-wise into sub-matrices B_j. Note that `C_j` must be `CSR` format where the nonzero
+ * elements of the `i`th row are located in ``data[indptr[i]:indptr[i+1]]``.
+ * The column indices for row `i` are stored in
+ * ``indices[indptr[i]:indptr[i+1]]``.
+ *
+ * \tparam eT   element type of the matrices
+ * \tparam idxT integer type of the index arrays, must be at least 32 bit int
+ * \param[in] top_n the top n values to store
+ * \param[in] nrowsA the number of rows in A
+ * \param[in] ncolsB_vec the number of columns in each B_i sub-matrix
+ * \param[in] C_data_vec vector of the nonzero elements of each C_data_j sub-matrix
+ * \param[in] C_indptr_vec vector of arrays containing the row indices for `C_data_j` sub-matrices
+ * \param[in] C_indices_vec vector of arrays containing the column indices for the C_j sub-matrices
+ * \param[out] Z_data the nonzero elements of zipped Z matrix
+ * \param[out] Z_indptr array containing the row indices for zipped `Z_data`
+ * \param[out] Z_indices array containing the zipped column indices
+ */
+template <typename eT, typename idxT, iffInt<idxT> = true>
+inline void sp_matzip_topn_sorted(
+    const idxT top_n,
+    const idxT nrowsA,
+    const std::vector<idxT>& ncolsB_vec,
+    const std::vector<eT*>& C_data_vec,
+    const std::vector<idxT*>& C_indptr_vec,
+    const std::vector<idxT*>& C_indices_vec,
+    std::vector<eT>& Z_data,
+    std::vector<idxT>& Z_indptr,
+    std::vector<idxT>& Z_indices
+) {
+    idxT nnz = 0;
+    Z_indptr[0] = 0;
+    const int n_mat = C_data_vec.size();
+
+    // threshold is already consistent between matrices, so accept every line.
+    auto max_heap = MaxHeap<eT, idxT>(top_n, std::numeric_limits<eT>::min());
+
+    // offset the index when concatenating the C sub-matrices (split by row)
+    std::vector<idxT> offset(n_mat, idxT(0));
+    for (int i = 0; i < n_mat - 1; ++i) {
+        for (int j = i; j < n_mat - 1; ++j) {
+            offset[j + 1] += ncolsB_vec[i];
+        }
+    }
+
+    // concatenate the results of each row, apply top_n and add those results to the C matrix
+    for (idxT i = 0; i < nrowsA; ++i) {
+
+        eT min = max_heap.reset();
+
+        // keep topn of stacked lines for each row
+        // insert in reverse order, similar to the reverse linked list in sp_matmul_topn()
+        for (int j = n_mat - 1; j >= 0; --j) {
+            for (idxT k = (*C_indptr_vec[j])[i]; k < (*C_indptr_vec[j])[i + 1]; ++k) {
+                eT val = (*C_data_vec[j])[k];
+                if (val > min) {
+                    min = max_heap.push_pop( offset[j] + (*C_indices_vec[j])[k], val );
+                }
+            }
+        }
+
+        // sort the heap s.t. the first value is the largest
+        max_heap.value_sort();
+
+        // fill the zipped sparse matrix C.
+        int n_set = max_heap.get_n_set();
+        for (int ii = 0; ii < n_set; ++ii) {
+            Z_indices.push_back(max_heap.heap[ii].idx);
+            Z_data.push_back(max_heap.heap[ii].val);
+        }
+        nnz += n_set;
+        Z_indptr[i + 1] = nnz;
+    }
+}
 
 }  // namespace sdtn::core


### PR DESCRIPTION
Function sp_matzip_topn_sorted will return a zipped matrix Z in CSR format, zip_j C_j, where Z = [sorted top n results > lower_bound for each row of C_j], where C_j = A.dot(B_j) and where B has been split row-wise into sub-matrices B_j.

Function only allows for sorted variant of sp_matzip function; unsorted variant (sorted based on insertion order) cannot be (made) equal to unsorted function on full matrices. sp_matzip_topn_sorted by default sorts by value.

And added python function to zip split matrices
Plus added unit test to test functionality